### PR TITLE
Add sheet info route and tool

### DIFF
--- a/LLM.txt
+++ b/LLM.txt
@@ -415,8 +415,10 @@ The current implementation provides these tools organized by category:
 - **get_revit_status**: Check if the Revit MCP API is active and responding
 - **get_revit_model_info**: Get comprehensive information about the current Revit model
 
-### **Model Information Tools**  
+### **Model Information Tools**
 - **list_levels**: Get all levels with elevation information in the current Revit model
+- **list_sheets**: Get a list of all sheets in the current Revit model
+- **get_sheet_info**: Get detailed information about a sheet by number
 
 ### **View & Image Tools**
 - **get_revit_view**: Export a specific Revit view as an image
@@ -459,9 +461,11 @@ The pyRevit extension exposes these HTTP endpoints under `http://localhost:48884
 ### **Status Endpoints**
 - `GET /status/` - Health check and API status
 
-### **Model Information Endpoints**  
+### **Model Information Endpoints**
 - `GET /model_info/` - Comprehensive model information
 - `GET /list_levels/` - Get all levels with elevation information
+- `GET /list_sheets/` - Get all sheets in the current model
+- `GET /sheet_info/<sheet_number>` - Get detailed information about a specific sheet
 
 ### **View Endpoints**
 - `GET /get_view/<view_name>` - Export specific view as PNG image

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ It contains:
 | `get_revit_status` | ✅ Implemented | Status & Connectivity | Check if the Revit MCP API is active and responding |
 | `get_revit_model_info` | ✅ Implemented | Model Information | Get comprehensive information about the current Revit model |
 | `list_levels` | ✅ Implemented | Model Information | Get all levels with elevation information |
+| `list_sheets` | ✅ Implemented | Model Information | Get a list of all sheets in the model |
+| `get_sheet_info` | ✅ Implemented | Model Information | Get detailed information about a specific sheet |
 | `get_revit_view` | ✅ Implemented | View & Image | Export a specific Revit view as an image |
 | `list_revit_views` | ✅ Implemented | View & Image | Get a list of all exportable views organized by type |
 | `place_family` | ✅ Implemented | Family & Placement | Place a family instance at specified location with custom properties |

--- a/revit-mcp-python.extension/revit_mcp/sheets.py
+++ b/revit-mcp-python.extension/revit_mcp/sheets.py
@@ -1,0 +1,154 @@
+# -*- coding: UTF-8 -*-
+"""
+Sheets Module for Revit MCP
+Provides sheet listing functionality
+"""
+
+from pyrevit import routes, revit, DB
+import logging
+
+from utils import get_element_name_safe
+
+logger = logging.getLogger(__name__)
+
+
+def register_sheet_routes(api):
+    """Register sheet-related routes with the API"""
+
+    @api.route('/list_sheets/', methods=["GET"])
+    def list_sheets(doc):
+        """Get a list of all sheets in the current Revit model"""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"},
+                    status=503
+                )
+
+            logger.info("Listing all sheets")
+
+            sheets = (
+                DB.FilteredElementCollector(doc)
+                .OfCategory(DB.BuiltInCategory.OST_Sheets)
+                .WhereElementIsNotElementType()
+                .ToElements()
+            )
+
+            sheets_info = []
+            for sheet in sheets:
+                try:
+                    sheet_number = sheet.SheetNumber
+                    sheet_name = get_element_name_safe(sheet)
+                    sheets_info.append({
+                        "number": sheet_number,
+                        "name": sheet_name,
+                        "id": sheet.Id.IntegerValue
+                    })
+                except Exception as e:
+                    logger.warning("Could not process sheet: {}".format(str(e)))
+                    continue
+
+            sheets_info.sort(key=lambda x: (x["number"], x["name"]))
+
+            return routes.make_response(data={
+                "sheets": sheets_info,
+                "total_sheets": len(sheets_info),
+                "status": "success"
+            })
+
+        except Exception as e:
+            logger.error("Failed to list sheets: {}".format(str(e)))
+            return routes.make_response(
+                data={"error": "Failed to list sheets: {}".format(str(e))},
+                status=500
+            )
+
+    logger.info("Sheets routes registered successfully")
+
+    @api.route('/sheet_info/<sheet_number>', methods=["GET"])
+    def sheet_info(doc, sheet_number):
+        """Get detailed information about a single sheet by sheet number"""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"},
+                    status=503,
+                )
+
+            logger.info("Getting info for sheet %s", sheet_number)
+
+            sheet = None
+            sheets = (
+                DB.FilteredElementCollector(doc)
+                .OfCategory(DB.BuiltInCategory.OST_Sheets)
+                .WhereElementIsNotElementType()
+                .ToElements()
+            )
+            for sh in sheets:
+                try:
+                    if sh.SheetNumber == sheet_number:
+                        sheet = sh
+                        break
+                except Exception:
+                    continue
+
+            if not sheet:
+                return routes.make_response(
+                    data={"error": "Sheet {} not found".format(sheet_number)},
+                    status=404,
+                )
+
+            # Get placed views on the sheet
+            placed_views = []
+            try:
+                view_ids = sheet.GetAllPlacedViews()
+                for vid in view_ids:
+                    view = doc.GetElement(vid)
+                    if view:
+                        placed_views.append(
+                            {
+                                "id": view.Id.IntegerValue,
+                                "name": get_element_name_safe(view),
+                                "type": str(view.ViewType),
+                            }
+                        )
+            except Exception as e:
+                logger.warning("Failed to collect views: %s", str(e))
+
+            # Text notes and other elements
+            text_notes = []
+            other_elements = []
+            try:
+                collector = DB.FilteredElementCollector(doc, sheet.Id)
+                for el in collector.WhereElementIsNotElementType().ToElements():
+                    if isinstance(el, DB.TextNote):
+                        text_notes.append(el.Text)
+                    elif not isinstance(el, DB.Viewport):
+                        cat = el.Category.Name if el.Category else "Unknown"
+                        other_elements.append(
+                            {
+                                "id": el.Id.IntegerValue,
+                                "name": get_element_name_safe(el),
+                                "category": cat,
+                            }
+                        )
+            except Exception as e:
+                logger.warning("Failed to collect sheet elements: %s", str(e))
+
+            return routes.make_response(
+                data={
+                    "sheet_number": sheet.SheetNumber,
+                    "sheet_name": get_element_name_safe(sheet),
+                    "views": placed_views,
+                    "text_notes": text_notes,
+                    "elements": other_elements,
+                    "status": "success",
+                }
+            )
+
+        except Exception as e:
+            logger.error("Failed to get sheet info: %s", str(e))
+            return routes.make_response(
+                data={"error": "Failed to get sheet info: {}".format(str(e))},
+                status=500,
+            )

--- a/revit-mcp-python.extension/startup.py
+++ b/revit-mcp-python.extension/startup.py
@@ -33,6 +33,10 @@ def register_routes():
 
         register_placement_routes(api)
 
+        from revit_mcp.sheets import register_sheet_routes
+
+        register_sheet_routes(api)
+
         from revit_mcp.colors import register_color_routes
 
         register_color_routes(api)

--- a/tools/model_tools.py
+++ b/tools/model_tools.py
@@ -10,3 +10,14 @@ def register_model_tools(mcp, revit_get):
     async def list_levels(ctx: Context = None) -> str:
         """Get a list of all levels in the current Revit model"""
         return await revit_get("/list_levels/", ctx)
+
+    @mcp.tool()
+    async def list_sheets(ctx: Context = None) -> str:
+        """Get a list of all sheets in the current Revit model"""
+        return await revit_get("/list_sheets/", ctx)
+
+    @mcp.tool()
+    async def get_sheet_info(sheet_number: str, ctx: Context = None) -> str:
+        """Get detailed information about a sheet by number"""
+        endpoint = f"/sheet_info/{sheet_number}"
+        return await revit_get(endpoint, ctx)


### PR DESCRIPTION
## Summary
- add `/sheet_info/<sheet_number>` API route in extension
- expose new `get_sheet_info` tool
- document sheet info tool in README and LLM guide

## Testing
- `python -m py_compile revit-mcp-python.extension/revit_mcp/sheets.py tools/model_tools.py revit-mcp-python.extension/startup.py`

------
https://chatgpt.com/codex/tasks/task_e_6864000a32ec8325b94f48c04bac2b76