### PR TITLE
Add sheet PDF export functionality

### DIFF
--- a/.well-known/openapi.yaml
+++ b/.well-known/openapi.yaml
@@ -257,3 +257,30 @@ paths:
             application/json:
               schema:
                 type: object
+
+  /export_sheets_pdf/:
+    post:
+      summary: Export selected sheets to a PDF
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sheets:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: PDF export result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pdf_data:
+                    type: string
+                  sheets_exported:
+                    type: integer

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ It contains:
 | `list_levels` | ✅ Implemented | Model Information | Get all levels with elevation information |
 | `list_sheets` | ✅ Implemented | Model Information | Get a list of all sheets in the model |
 | `get_sheet_info` | ✅ Implemented | Model Information | Get detailed information about a specific sheet |
+| `export_sheets_pdf` | ✅ Implemented | Model Information | Export one or more sheets to a combined PDF |
 | `get_revit_view` | ✅ Implemented | View & Image | Export a specific Revit view as an image |
 | `list_revit_views` | ✅ Implemented | View & Image | Get a list of all exportable views organized by type |
 | `place_family` | ✅ Implemented | Family & Placement | Place a family instance at specified location with custom properties |

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -15,7 +15,7 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_status_tools(mcp_server, revit_get_func)
     register_view_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
     register_family_tools(mcp_server, revit_get_func, revit_post_func)
-    register_model_tools(mcp_server, revit_get_func)
+    register_model_tools(mcp_server, revit_get_func, revit_post_func)
     register_colors_tools(mcp_server, revit_get_func, revit_post_func)
     register_code_execution_tools(
         mcp_server, revit_get_func, revit_post_func, revit_image_func

--- a/tools/model_tools.py
+++ b/tools/model_tools.py
@@ -3,7 +3,7 @@
 from mcp.server.fastmcp import Context
 
 
-def register_model_tools(mcp, revit_get):
+def register_model_tools(mcp, revit_get, revit_post):
     """Register model structure tools"""
     
     @mcp.tool()
@@ -21,3 +21,9 @@ def register_model_tools(mcp, revit_get):
         """Get detailed information about a sheet by number"""
         endpoint = f"/sheet_info/{sheet_number}"
         return await revit_get(endpoint, ctx)
+
+    @mcp.tool()
+    async def export_sheets_pdf(sheets: list, ctx: Context = None) -> str:
+        """Export specified sheets to a PDF and return encoded data"""
+        payload = {"sheets": sheets}
+        return await revit_post("/export_sheets_pdf/", payload, ctx)


### PR DESCRIPTION
## Summary
- export selected sheets in Revit to PDF via new `/export_sheets_pdf/` route
- expose new `export_sheets_pdf` tool for MCP clients
- document the endpoint in `openapi.yaml`
- list the new tool in README

## Testing
- `python -m py_compile revit-mcp-python.extension/revit_mcp/sheets.py tools/model_tools.py tools/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68646d0983fc8325aaf6842acde672ef