### PR TITLE
Sanitize route responses

### DIFF
--- a/revit-mcp-python.extension/revit_mcp/code_execution.py
+++ b/revit-mcp-python.extension/revit_mcp/code_execution.py
@@ -4,6 +4,7 @@ Code Execution Module for Revit MCP
 Handles direct execution of IronPython code in Revit context.
 """
 from pyrevit import routes, revit, DB
+from utils import safe_make_response
 import json
 import logging
 import sys
@@ -39,7 +40,7 @@ def register_code_execution_routes(api):
             description = data.get("description", "Code execution")
 
             if not code_to_execute:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No code provided"}, status=400
                 )
 
@@ -79,7 +80,7 @@ def register_code_execution_routes(api):
                 # Commit the transaction
                 t.Commit()
 
-                return routes.make_response(
+                return safe_make_response(
                     data={
                         "status": "success",
                         "description": description,
@@ -106,7 +107,7 @@ def register_code_execution_routes(api):
                 logger.error("Code execution failed: {}".format(str(exec_error)))
                 logger.error("Traceback: {}".format(error_traceback))
 
-                return routes.make_response(
+                return safe_make_response(
                     data={
                         "status": "error",
                         "error": str(exec_error),
@@ -118,6 +119,6 @@ def register_code_execution_routes(api):
 
         except Exception as e:
             logger.error("Execute code request failed: {}".format(str(e)))
-            return routes.make_response(data={"error": str(e)}, status=500)
+            return safe_make_response(data={"error": str(e)}, status=500)
 
     logger.info("Code execution routes registered successfully.")

--- a/revit-mcp-python.extension/revit_mcp/colors.py
+++ b/revit-mcp-python.extension/revit_mcp/colors.py
@@ -9,7 +9,7 @@ import json
 import logging
 import random
 from collections import defaultdict
-from .utils import normalize_string
+from .utils import normalize_string, safe_make_response
 
 logger = logging.getLogger(__name__)
 
@@ -966,7 +966,7 @@ def register_color_routes(api):
             custom_colors = data.get("custom_colors", None)
 
             if not category_name or not parameter_name:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "category_name and parameter_name are required"},
                     status=400,
                 )
@@ -975,11 +975,11 @@ def register_color_routes(api):
                 doc, category_name, parameter_name, use_gradient, custom_colors
             )
 
-            return routes.make_response(data=result)
+            return safe_make_response(data=result)
 
         except Exception as e:
             logger.error("Error in color_splash route: %s", e)
-            return routes.make_response(data={"error": str(e)}, status=500)
+            return safe_make_response(data={"error": str(e)}, status=500)
 
     @api.route("/clear_colors/", methods=["POST"])
     def clear_colors(doc, request):
@@ -1001,17 +1001,17 @@ def register_color_routes(api):
             category_name = data.get("category_name")
 
             if not category_name:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "category_name is required"}, status=400
                 )
 
             result = clear_element_colors(doc, category_name)
 
-            return routes.make_response(data=result)
+            return safe_make_response(data=result)
 
         except Exception as e:
             logger.error("Error in clear_colors route: %s", e)
-            return routes.make_response(data={"error": str(e)}, status=500)
+            return safe_make_response(data={"error": str(e)}, status=500)
 
     @api.route("/list_category_parameters/", methods=["POST"])
     def list_parameters(doc, request):
@@ -1033,17 +1033,17 @@ def register_color_routes(api):
             category_name = data.get("category_name")
 
             if not category_name:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "category_name is required"}, status=400
                 )
 
             result = list_category_parameters(doc, category_name)
 
-            return routes.make_response(data=result)
+            return safe_make_response(data=result)
 
         except Exception as e:
             logger.error("Error in list_category_parameters route: %s", e)
-            return routes.make_response(data={"error": str(e)}, status=500)
+            return safe_make_response(data={"error": str(e)}, status=500)
 
 
 def get_numeric_parameter_raw_value(param):

--- a/revit-mcp-python.extension/revit_mcp/model_info.py
+++ b/revit-mcp-python.extension/revit_mcp/model_info.py
@@ -32,8 +32,8 @@ def register_model_info_routes(api):
         try:
             doc = revit.doc
             if not doc:
-                return routes.make_response(
-                    data={"error": "No active Revit document"}, 
+                return safe_make_response(
+                    data={"error": "No active Revit document"},
                     status=503
                 )
 
@@ -290,12 +290,12 @@ def register_model_info_routes(api):
                 }
             }
 
-            return routes.make_response(data=model_data)
+            return safe_make_response(data=model_data)
             
         except Exception as e:
             logger.error("Failed to get model info: {}".format(str(e)))
-            return routes.make_response(
-                data={"error": "Failed to retrieve model information: {}".format(str(e))}, 
+            return safe_make_response(
+                data={"error": "Failed to retrieve model information: {}".format(str(e))},
                 status=500
             )
     

--- a/revit-mcp-python.extension/revit_mcp/placement.py
+++ b/revit-mcp-python.extension/revit_mcp/placement.py
@@ -36,14 +36,14 @@ def register_placement_routes(api):
         """
         try:
             if not doc:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active Revit document"}, 
                     status=503
                 )
             
             # Parse request data
             if not request or not request.data:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No data provided or invalid request format"},
                     status=400
                 )
@@ -54,7 +54,7 @@ def register_placement_routes(api):
                 try:
                     data = json.loads(request.data)
                 except Exception as json_err:
-                    return routes.make_response(
+                    return safe_make_response(
                         data={"error": "Invalid JSON format: {}".format(str(json_err))},
                         status=400
                     )
@@ -63,7 +63,7 @@ def register_placement_routes(api):
                 
             # Validate data structure
             if not data or not isinstance(data, dict):
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "Invalid data format - expected JSON object"},
                     status=400
                 )
@@ -78,14 +78,14 @@ def register_placement_routes(api):
             
             # Basic validation
             if not family_name:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No family_name provided"},
                     status=400
                 )
                 
             # Validate location
             if not location or not all(k in location for k in ["x", "y", "z"]):
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "Invalid location - must include x, y, z coordinates"},
                     status=400
                 )
@@ -111,7 +111,7 @@ def register_placement_routes(api):
                 except:
                     available_families = ["Could not retrieve family list"]
                 
-                return routes.make_response(
+                return safe_make_response(
                     data={
                         "error": "Family type not found: {} - {}".format(family_name, type_name or "Any"),
                         "available_families": available_families[:20]  # Show first 20
@@ -137,7 +137,7 @@ def register_placement_routes(api):
                         continue
                 
                 if not target_level:
-                    return routes.make_response(
+                    return safe_make_response(
                         data={"error": "Level not found: {}".format(level_name)},
                         status=404
                     )
@@ -150,7 +150,7 @@ def register_placement_routes(api):
                     float(location["z"])
                 )
             except (ValueError, TypeError) as coord_error:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "Invalid coordinates: {}".format(str(coord_error))},
                     status=400
                 )
@@ -264,7 +264,7 @@ def register_placement_routes(api):
                     "properties_failed": properties_failed
                 }
                 
-                return routes.make_response(data=response_data)
+                return safe_make_response(data=response_data)
                     
             except Exception as tx_error:
                 # Roll back the transaction if something went wrong
@@ -276,7 +276,7 @@ def register_placement_routes(api):
         except Exception as e:
             logger.error("Failed to place family: {}".format(str(e)))
             error_trace = traceback.format_exc()
-            return routes.make_response(
+            return safe_make_response(
                 data={"error": str(e), "traceback": error_trace},
                 status=500
             )
@@ -290,7 +290,7 @@ def register_placement_routes(api):
         """
         try:
             if not doc:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active Revit document"}, 
                     status=503
                 )
@@ -313,14 +313,14 @@ def register_placement_routes(api):
                     })
                 except Exception:
                     continue
-            return routes.make_response(data={
+            return safe_make_response(data={
                 "families": families,
                 "truncated_total": len(families),
                 "status": "success"
             })
         except Exception as e:
             logger.error("Failed to list families: {}".format(str(e)))
-            return routes.make_response(
+            return safe_make_response(
                 data={"error": "Failed to list families: {}".format(str(e))},
                 status=500
             )
@@ -336,7 +336,7 @@ def register_placement_routes(api):
         """
         try:
             if not doc:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active Revit document"}, 
                     status=503
                 )
@@ -370,7 +370,7 @@ def register_placement_routes(api):
             # Sort by name
             sorted_categories = dict(sorted(categories.items()))
             
-            return routes.make_response(data={
+            return safe_make_response(data={
                 "categories": sorted_categories,
                 "total_categories": len(sorted_categories),
                 "status": "success"
@@ -378,7 +378,7 @@ def register_placement_routes(api):
             
         except Exception as e:
             logger.error("Failed to list family categories: {}".format(str(e)))
-            return routes.make_response(
+            return safe_make_response(
                 data={"error": "Failed to list family categories: {}".format(str(e))},
                 status=500
             )
@@ -393,7 +393,7 @@ def register_placement_routes(api):
         """
         try:
             if not doc:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active Revit document"}, 
                     status=503
                 )
@@ -426,7 +426,7 @@ def register_placement_routes(api):
             # Sort by elevation
             levels_info.sort(key=lambda x: x["elevation"])
             
-            return routes.make_response(data={
+            return safe_make_response(data={
                 "levels": levels_info,
                 "total_levels": len(levels_info),
                 "status": "success"
@@ -434,7 +434,7 @@ def register_placement_routes(api):
             
         except Exception as e:
             logger.error("Failed to list levels: {}".format(str(e)))
-            return routes.make_response(
+            return safe_make_response(
                 data={"error": "Failed to list levels: {}".format(str(e))},
                 status=500
             )

--- a/revit-mcp-python.extension/revit_mcp/sheets.py
+++ b/revit-mcp-python.extension/revit_mcp/sheets.py
@@ -7,7 +7,7 @@ Provides sheet listing functionality
 from pyrevit import routes, revit, DB
 import logging
 
-from utils import get_element_name_safe
+from utils import get_element_name_safe, safe_make_response
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ def register_sheet_routes(api):
         """Get a list of all sheets in the current Revit model"""
         try:
             if not doc:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active Revit document"},
                     status=503
                 )
@@ -50,7 +50,7 @@ def register_sheet_routes(api):
 
             sheets_info.sort(key=lambda x: (x["number"], x["name"]))
 
-            return routes.make_response(data={
+            return safe_make_response(data={
                 "sheets": sheets_info,
                 "total_sheets": len(sheets_info),
                 "status": "success"
@@ -58,7 +58,7 @@ def register_sheet_routes(api):
 
         except Exception as e:
             logger.error("Failed to list sheets: {}".format(str(e)))
-            return routes.make_response(
+            return safe_make_response(
                 data={"error": "Failed to list sheets: {}".format(str(e))},
                 status=500
             )
@@ -70,7 +70,7 @@ def register_sheet_routes(api):
         """Get detailed information about a single sheet by sheet number"""
         try:
             if not doc:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active Revit document"},
                     status=503,
                 )
@@ -93,7 +93,7 @@ def register_sheet_routes(api):
                     continue
 
             if not sheet:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "Sheet {} not found".format(sheet_number)},
                     status=404,
                 )
@@ -135,7 +135,7 @@ def register_sheet_routes(api):
             except Exception as e:
                 logger.warning("Failed to collect sheet elements: %s", str(e))
 
-            return routes.make_response(
+            return safe_make_response(
                 data={
                     "sheet_number": sheet.SheetNumber,
                     "sheet_name": get_element_name_safe(sheet),
@@ -148,7 +148,7 @@ def register_sheet_routes(api):
 
         except Exception as e:
             logger.error("Failed to get sheet info: %s", str(e))
-            return routes.make_response(
+            return safe_make_response(
                 data={"error": "Failed to get sheet info: {}".format(str(e))},
                 status=500,
             )

--- a/revit-mcp-python.extension/revit_mcp/status.py
+++ b/revit-mcp-python.extension/revit_mcp/status.py
@@ -5,6 +5,7 @@ Handles API status and health check endpoints
 """
 
 from pyrevit import routes
+from utils import safe_make_response
 import logging
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,7 @@ def register_status_routes(api):
             
             doc = revit.doc
             if doc:
-                return routes.make_response(data={
+                return safe_make_response(data={
                     "status": "active",
                     "health": "healthy",
                     "revit_available": True,
@@ -33,7 +34,7 @@ def register_status_routes(api):
                     "api_name": "revit_mcp"
                 })
             else:
-                return routes.make_response(data={
+                return safe_make_response(data={
                     "status": "unhealthy", 
                     "revit_available": False,
                     "error": "No active Revit document",
@@ -42,7 +43,7 @@ def register_status_routes(api):
                 
         except Exception as e:
             logger.error("Health check failed:{}".format(str(e)))
-            return routes.make_response(data={
+            return safe_make_response(data={
                 "status": "unhealthy",
                 "revit_available": False, 
                 "error": str(e),

--- a/revit-mcp-python.extension/revit_mcp/views.py
+++ b/revit-mcp-python.extension/revit_mcp/views.py
@@ -33,7 +33,7 @@ def register_views_routes(api):
         """
         try:
             if not doc:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active Revit document"}, 
                     status=503
                 )
@@ -81,7 +81,7 @@ def register_views_routes(api):
                     except:
                         continue
                 
-                return routes.make_response(
+                return safe_make_response(
                     data={
                         "error": "View '{}' not found".format(view_name),
                         "available_views": available_views[:20]  # Limit to first 20 for readability
@@ -92,13 +92,13 @@ def register_views_routes(api):
             # Check if view can be exported
             try:
                 if hasattr(target_view, "IsTemplate") and target_view.IsTemplate:
-                    return routes.make_response(
+                    return safe_make_response(
                         data={"error": "Cannot export view templates"},
                         status=400
                     )
                     
                 if target_view.ViewType == DB.ViewType.Internal:
-                    return routes.make_response(
+                    return safe_make_response(
                         data={"error": "Cannot export internal views"},
                         status=400
                     )
@@ -133,13 +133,13 @@ def register_views_routes(api):
                 matching_files.sort(key=lambda x: os.path.getctime(x), reverse=True)
             except Exception as e:
                 logger.error("Could not list exported files: {}".format(str(e)))
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "Could not access export folder"},
                     status=500
                 )
             
             if not matching_files:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "Export failed - no image file was created"},
                     status=500
                 )
@@ -160,7 +160,7 @@ def register_views_routes(api):
                 
             except Exception as e:
                 logger.error("Could not read/encode image file: {}".format(str(e)))
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "Could not read exported image file"},
                     status=500
                 )
@@ -173,7 +173,7 @@ def register_views_routes(api):
                 except Exception as e:
                     logger.warning("Could not clean up temporary file: {}".format(str(e)))
 
-            return routes.make_response(data={
+            return safe_make_response(data={
                 "image_data": encoded_data,
                 "content_type": "image/png",
                 "view_name": view_name,
@@ -183,7 +183,7 @@ def register_views_routes(api):
 
         except Exception as e:
             logger.error("Failed to export view '{}': {}".format(view_name, str(e)))
-            return routes.make_response(
+            return safe_make_response(
                 data={"error": "Failed to export view: {}".format(str(e))},
                 status=500
             )
@@ -198,7 +198,7 @@ def register_views_routes(api):
         """
         try:
             if not doc:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active Revit document"}, 
                     status=503
                 )
@@ -260,7 +260,7 @@ def register_views_routes(api):
             # Count total exportable views
             total_views = sum(len(view_list) for view_list in views_by_type.values())
             
-            return routes.make_response(data={
+            return safe_make_response(data={
                 "views_by_type": views_by_type,
                 "total_exportable_views": total_views,
                 "status": "success"
@@ -268,7 +268,7 @@ def register_views_routes(api):
             
         except Exception as e:
             logger.error("Failed to list views: {}".format(str(e)))
-            return routes.make_response(
+            return safe_make_response(
                 data={"error": "Failed to list views: {}".format(str(e))},
                 status=500
             )
@@ -286,14 +286,14 @@ def register_views_routes(api):
         """
         try:
             if not uidoc or not uidoc.Document:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active Revit document"}, 
                     status=503
                 )
             
             current_view = uidoc.ActiveView
             if not current_view:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active view found"}, 
                     status=404
                 )
@@ -342,14 +342,14 @@ def register_views_routes(api):
             except Exception:
                 view_info["discipline"] = "Unknown"
                 
-            return routes.make_response(data={
+            return safe_make_response(data={
                 "status": "success", 
                 "view_info": view_info
             })
             
         except Exception as e:
             logger.error("Get current view info failed: {}".format(str(e)))
-            return routes.make_response(
+            return safe_make_response(
                 data={"error": "Failed to get current view info: {}".format(str(e))}, 
                 status=500
             )
@@ -368,14 +368,14 @@ def register_views_routes(api):
         """
         try:
             if not doc or not uidoc:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active Revit document"}, 
                     status=503
                 )
             
             current_view = uidoc.ActiveView
             if not current_view:
-                return routes.make_response(
+                return safe_make_response(
                     data={"error": "No active view found"}, 
                     status=404
                 )
@@ -482,11 +482,11 @@ def register_views_routes(api):
                 "category_counts": category_counts
             }
             
-            return routes.make_response(data=result)
+            return safe_make_response(data=result)
             
         except Exception as e:
             logger.error("Get current view elements failed: {}".format(str(e)))
-            return routes.make_response(
+            return safe_make_response(
                 data={"error": "Failed to get current view elements: {}".format(str(e))}, 
                 status=500
             )


### PR DESCRIPTION
## Summary
- add helpers to sanitize data for JSON serialization
- wrap `routes.make_response` with `safe_make_response`
- update all route modules to use the new wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646bb3e50c832583aa8c6d9730f9dd