### PR TITLE
Fix safe_make_response routes import

### DIFF
--- a/revit-mcp-python.extension/revit_mcp/utils.py
+++ b/revit-mcp-python.extension/revit_mcp/utils.py
@@ -1,4 +1,4 @@
-from pyrevit import DB
+from pyrevit import DB, routes
 import traceback
 import logging
 


### PR DESCRIPTION
## Summary
- include `routes` in utils so safe_make_response can call routes.make_response

## Testing
- `python -m py_compile revit-mcp-python.extension/revit_mcp/utils.py`
- `python -m py_compile revit-mcp-python.extension/revit_mcp/code_execution.py`


------
https://chatgpt.com/codex/tasks/task_e_6864757686608325a2b3ce2b3e4e5c98