### PR TITLE
Add sheet image export

### DIFF
--- a/.well-known/openapi.yaml
+++ b/.well-known/openapi.yaml
@@ -74,6 +74,34 @@ paths:
             application/json:
               schema:
                 type: object
+
+  /sheet_image/{sheet_number}:
+    get:
+      summary: Export a sheet as an image
+      parameters:
+        - in: path
+          name: sheet_number
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Image data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  image_data:
+                    type: string
+                  content_type:
+                    type: string
+                  sheet_number:
+                    type: string
+                  file_size_bytes:
+                    type: integer
+                  export_success:
+                    type: boolean
   /current_view_info/:
     get:
       summary: Get info for the active view

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ It contains:
 | `export_sheets_pdf` | ✅ Implemented | Model Information | Export one or more sheets to a combined PDF |
 | `get_revit_view` | ✅ Implemented | View & Image | Export a specific Revit view as an image |
 | `list_revit_views` | ✅ Implemented | View & Image | Get a list of all exportable views organized by type |
+| `get_sheet_image` | ✅ Implemented | View & Image | Export a sheet view as an image |
 | `place_family` | ✅ Implemented | Family & Placement | Place a family instance at specified location with custom properties |
 | `list_families` | ✅ Implemented | Family & Placement | Get a flat list of available family types (with filtering) |
 | `list_family_categories` | ✅ Implemented | Family & Placement | Get a list of all family categories in the model |

--- a/tools/view_tools.py
+++ b/tools/view_tools.py
@@ -17,6 +17,11 @@ def register_view_tools(mcp, revit_get, revit_post, revit_image):
         return await revit_get("/list_views/", ctx)
 
     @mcp.tool()
+    async def get_sheet_image(sheet_number: str, ctx: Context = None) -> str:
+        """Export a sheet as an image"""
+        return await revit_image(f"/sheet_image/{sheet_number}", ctx)
+
+    @mcp.tool()
     async def get_current_view_info(ctx: Context = None) -> str:
         """
         Get detailed information about the currently active view in Revit.


### PR DESCRIPTION
## Summary
- allow exporting sheet views as PNG images via new API endpoint
- provide corresponding `get_sheet_image` tool
- document the new functionality in README and OpenAPI spec

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68655a7d2028832586c8c55acc7f0038